### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ So, the command goes in -> the bus hands it off to a handler -> and then the han
 You can have more informations [here](http://culttt.com/2014/11/10/creating-using-command-bus/).
 
 # Installation
-## Cocoapods
+## CocoaPods
 CommandBus is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
